### PR TITLE
[Neuropixels] Add time shift to processed behavior data timestamp columns

### DIFF
--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/interfaces/schierek_embargo_2024_processedbehaviorinterface.py
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/interfaces/schierek_embargo_2024_processedbehaviorinterface.py
@@ -161,6 +161,96 @@ class SchierekEmbargo2024ProcessedBehaviorInterface(BaseDataInterface):
             data=center_port_offset_times + time_shift,
         )
 
+        side_port_columns = ["Cled", "Lled", "Rled", "l_opt", "r_opt"]
+        missing_columns = [col for col in side_port_columns if col not in data]
+        if missing_columns:
+            raise ValueError(f"Missing required columns in data: {', '.join(missing_columns)}")
+
+        # During the delay between the center light turning off and the reward arriving, the side light turns on.
+        # The side light turns off when the reward is available, then stays off until the animal collects the reward.
+        # When the animal nose pokes to collect the reward, the light flashes on/off.
+        reward_side_light_onset_times = []
+        reward_side_light_offset_times = []
+        reward_side_light_flash_onset_times = []
+        reward_side_light_flash_offset_times = []
+
+        opt_out_side_light_onset_times = []
+        opt_out_side_light_offset_times = []
+        opt_out_reward_port_turns_off = []
+        opt_out_reward_port_light_turns_off = []
+
+        for i in range(num_trials):
+            rewarded_side = data["RewardedSide"][i]
+            if rewarded_side == "Left":
+                side_port_column_name = "Lled"
+                # the opt-out port is the opposite of the rewarded side
+                opt_out_port_column_name = "r_opt"
+            elif rewarded_side == "Right":
+                side_port_column_name = "Rled"
+                opt_out_port_column_name = "l_opt"
+            else:
+                raise ValueError(f"Invalid rewarded side '{rewarded_side}'.")
+
+            reward_side_light_onset_times.append(data[side_port_column_name][i][0])
+            reward_side_light_offset_times.append(data[side_port_column_name][i][1])
+            reward_side_light_flash_onset_times.append(data[side_port_column_name][i][2])
+            reward_side_light_flash_offset_times.append(data[side_port_column_name][i][3])
+
+            opt_out_side_light_onset_times.append(data[opt_out_port_column_name][i][0])
+            opt_out_side_light_offset_times.append(data[opt_out_port_column_name][i][1])
+            opt_out_reward_port_turns_off.append(data[side_port_column_name][i][3])
+            opt_out_reward_port_light_turns_off.append(data[opt_out_port_column_name][i][3])
+
+        trials_table.add_column(
+            name="rewarded_port_onset_time",
+            description="The time of reward port light on for each trial. During the delay between the center light turning off and the reward arriving, the side light turns on.",
+            data=reward_side_light_onset_times + time_shift,
+        )
+
+        trials_table.add_column(
+            name="rewarded_port_offset_time",
+            description="The time of reward port light off for each trial. The side light turns off when the reward is available, then stays off until the animal collects the reward.",
+            data=reward_side_light_offset_times + time_shift,
+        )
+
+        trials_table.add_column(
+            name="rewarded_port_flash_onset_time",
+            description="The time of reward port light flash on for each trial. When the animal nose pokes to collect the reward, the light flashes on/off.",
+            data=reward_side_light_flash_onset_times + time_shift,
+        )
+
+        trials_table.add_column(
+            name="rewarded_port_flash_offset_time",
+            description="The time of reward port light flash off for each trial. When the animal nose pokes to collect the reward, the light flashes on/off.",
+            data=reward_side_light_flash_offset_times + time_shift,
+        )
+
+        trials_table.add_column(
+            name="opt_out_port_onset_time",
+            description=f"The time of side light turns on when the animal opts out by poking into the port opposite to the rewarded side.",
+            data=opt_out_side_light_onset_times + time_shift,
+        )
+
+        trials_table.add_column(
+            name="opt_out_port_offset_time",
+            description=f"The time of side light turns off when the animal opts out by poking into the port opposite to the rewarded side.",
+            data=opt_out_side_light_offset_times + time_shift,
+        )
+
+        trials_table.add_column(
+            name=f"opt_out_reward_port_offset_time",
+            description="The time of rewarded port turns off when the animal opts out by poking into the port opposite to the rewarded side.",
+            data=opt_out_reward_port_turns_off + time_shift,
+        )
+
+        trials_table.add_column(
+            name=f"opt_out_reward_port_light_offset_time",
+            description="The time of rewarded port light turns off when the animal opts out by poking into the port opposite to the rewarded side.",
+            data=opt_out_reward_port_light_turns_off + time_shift,
+        )
+
+        # filter columns to add, these columns were added separately
+        columns_to_add = [column for column in columns_to_add if column not in side_port_columns]
         for column_name in columns_to_add:
             name = column_name_mapping.get(column_name, column_name) if column_name_mapping is not None else column_name
             description = (

--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_notes.md
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_notes.md
@@ -171,6 +171,9 @@ We are aligning the starting time of the recording and sorting interfaces to the
 
 We are computing the time shift from the Bpod trial start time to the NIDAQ trial start time.
 
+From a conceptual point of view, the trial start and the central port onset are equivalent: a trial starts when the first time the central port is on.
+
+
 ```python
 time_shift = bpod_trial_start_times[0] - center_port_onset_times[0]
 >>> -28.58217236918037

--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_nwbconverter.py
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_nwbconverter.py
@@ -115,6 +115,10 @@ class SchierekEmbargo2024NWBConverter(NWBConverter):
     def get_metadata(self):
         metadata = super().get_metadata()
 
+        # Explicity set session_start_time to Bpod start time
+        session_start_time = self.data_interface_objects["RawBehavior"].get_metadata()["NWBFile"]["session_start_time"]
+        metadata["NWBFile"].update(session_start_time=session_start_time)
+
         if "Electrodes" not in metadata["Ecephys"]:
             metadata["Ecephys"]["Electrodes"] = []
 


### PR DESCRIPTION
To align with Bpod, this PR implements the shifting of timestamp columns in the processed behavior data.
The columns that need to be shifted:
- "Cled"
- "Lled"
- "Rled"
- "l_opt"
- "r_opt"

See #31 

This PR also includes the changes how we are storing "Lled", "Rled","l_opt" and "r_opt" columns.
Before we added the 4 timestamp for each trial in the same column, just as:
<img width="613" alt="Screenshot 2024-12-02 at 18 36 15 (2)" src="https://github.com/user-attachments/assets/989865c0-1390-45f6-a34c-991ff2c1cb7a">

The 4 timestamp for each trial is from:

e.g. Lled = [left reward side light on, left  reward side light off,  left reward side light flash on, left reward side light flash off] 

l_opt = [left side light turns on, left side light turns off, right port turns off,  side light turns off]

> During the delay between the center light turning off and the reward arriving, the side light turns on. The side light turns off when the reward is available, then stays off until the animal collects the reward. When the animal nose pokes to collect the reward, the light flashes on/off.
Alternatively, if the animal opts out, there is a flash on the opt out port on/off. Then the reward port turns off. 

I think it is better not to store them as arrays in the trials table but break them into separate columns, e.g.

rewarded_port_onset_time -> corresponds to the first timestamp of "Lled" if the rewarded side for that trials was the left port
rewarded_port_offset_time -> corresponds to the second timestamp of "Lled" if the rewarded side for that trials was the left port
rewarded_port_flash_onset_time -> corresponds to the third timestamp of "Lled" if the rewarded side for that trials was the left port
rewarded_port_flash_offset_time -> corresponds to the fourth timestamp of "Lled" if the rewarded side for that trials was the left port

We populate rewarded_port_onset_time, rewarded_port_offset_time, rewarded_port_flash_onset_time, rewarded_port_flash_offset_time etc. for each trial depending on which side was the rewarded side.
