### PR TITLE
[Neuropixels] Final updates for session_to_nwb

### DIFF
--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_ecephys_metadata.yaml
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_ecephys_metadata.yaml
@@ -12,7 +12,7 @@ Ecephys:
     description: The raw acquisition traces from Neuropixels probe (384 channels, 30 kHz sampling rate) using Neuropix-PXI hardware and OpenEphys.
   lfp_electrical_series:
     name: lfp_electrical_series
-    description: The processed traces from the Neuropixels probe (384 channels, 1 kHz sampling rate) using Neuropix-PXI hardware and OpenEphys.
+    description: The processed traces from the Neuropixels probe (384 channels, 2.5 kHz sampling rate) using Neuropix-PXI hardware and OpenEphys.
   UnitProperties:
     - name: channel_depth_um
       description: The distance of the channel from the tip of the neuropixels probe in micrometers.


### PR DESCRIPTION
Minor updates for the Neuropixels dataset `session_to_nwb` function.

- Changed a typo in the LFP series description (sampling rate is 2.5kHz and not 1kHz)
- propagate `ap_stream_name` and `lfp_stream` name to `session_to_nwb`
- Add descriptions for unit tables
- Automatically determine the Phy spike sorting folder path knowing it is always in the recording folder where the raw recording is

Some stream names  (e.g. "Neuropix-PXI-100.0") might not contain the "AP" or "LFP" substring in their names, so it is not possible to automatically determine which stream corresponds to AP or LF stream. 