### PR TITLE
[Neuropixels] Support optogenetics protocol

### DIFF
--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_behavior_metadata.yaml
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_behavior_metadata.yaml
@@ -276,6 +276,6 @@ Behavior:
       output_type: numeric
     OptoEvent:
       name: opto_event_type
-      description: The type of optogenetic event.
+      description: The type of optogenetic event. (1 = center port in, 2 = side port off, 3 = Reward or opt-out, 4 = stimulation on, 5 = delay)
       expression_type: integer
       output_type: numeric

--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_behavior_metadata.yaml
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_behavior_metadata.yaml
@@ -42,6 +42,12 @@ Behavior:
       name: go_cue
     WaitForSidePoke:
       name: wait_for_side_poke
+    WaitForSidePoke_beforeStim:
+      name: wait_for_side_poke_before_stimulation
+    WaitForSidePoke_duringStim:
+      name: wait_for_side_poke_during_stimulation
+    WaitForSidePoke_afterStim:
+      name: wait_for_side_poke_after_stimulation
     PortOut:
       name: port_out
     AnnounceReward:
@@ -251,5 +257,25 @@ Behavior:
     TrialsStage8:
       name: num_trials_in_stage_8
       description: Determines how many trials occur in stage 8 before transition.
+      expression_type: integer
+      output_type: numeric
+    ProbOpto:
+      name: opto_probability
+      description: The probability of a trial being an optogenetic trial.
+      expression_type: double
+      output_type: numeric
+    IsOpto:
+      name: is_opto
+      description: Whether the trial is an optogenetic trial.
+      expression_type: boolean
+      output_type: boolean
+    ProbOptoEvent:
+      name: opto_event_probability
+      description: The probability of an optogenetic event occurring.
+      expression_type: double
+      output_type: numeric
+    OptoEvent:
+      name: opto_event_type
+      description: The type of optogenetic event.
       expression_type: integer
       output_type: numeric

--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_optogenetics_stimulation_metadata.yaml
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/metadata/schierek_embargo_2024_optogenetics_stimulation_metadata.yaml
@@ -1,0 +1,16 @@
+# This is an optional file that can be used to define metadata for the Neuropixels sessions with optogenetic stimulation data.
+# Modify the metadata as needed to describe the stimulation parameters and the site of stimulation. The values are examples.
+Stimulus:
+   OptogeneticStimulusSite:
+     - name: optogenetic_stimulus_site
+       description: The site where the optogenetic stimulation was applied.
+       excitation_lambda: 465.0 # Excitation wavelength in nanometers.
+       location: DMS # The brain area where the stimulation was applied.
+   OptogeneticSeries:
+     name: optogenetic_series
+     site: optogenetic_stimulus_site
+     description: Notes on the optogenetic stimulation.
+     duration: 0.5 # Duration of the optogenetic stimulation in seconds.
+     frequency: 40.0 # Frequency of the optogenetic stimulation in Hz.
+     pulse_width: 0.005 # Pulse width of the optogenetic stimulation in seconds.
+     power: 0.0023 # Power of the optogenetic stimulation in W.

--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_convert_session.py
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_convert_session.py
@@ -248,6 +248,14 @@ def session_to_nwb(
     ephys_metadata = load_dict_from_file(ephys_metadata_path)
     metadata = dict_deep_update(metadata, ephys_metadata)
 
+    if "opto" in protocol.lower():
+        # Load optogenetics_stimulation_metadata
+        ogen_metadata_path = (
+            Path(__file__).parent / "metadata" / "schierek_embargo_2024_optogenetics_stimulation_metadata.yaml"
+        )
+        ogen_metadata = load_dict_from_file(ogen_metadata_path)
+        metadata = dict_deep_update(metadata, ogen_metadata)
+
     if ephys_registry_file_path is not None:
         metadata = update_ephys_device_metadata_for_subject(
             epys_registry_file_path=ephys_registry_file_path,

--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_notes.md
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_notes.md
@@ -309,3 +309,27 @@ probe = probeinterface.read_openephys(
 )
 assert len(probe.contact_ids) == 384
 ```
+
+## Optogenetics protocol
+
+Some sessions may include optogenetic stimulation protocols. The stimulation onset times are retrieved
+from the Bpod data ("RWTautowait2OptoTest") from trials where the "OptoEvent" is 4 (stimulation on).
+
+The stimulation parameters should be updated in the `schierek_embargo_2024/metadata/schierek_embargo_2024_optogenetics_stimulation_metadata.yaml` file.
+
+```yaml
+Stimulus:
+   OptogeneticStimulusSite:
+     - name: optogenetic_stimulus_site
+       description: The site where the optogenetic stimulation was applied.
+       excitation_lambda: 465.0 # Excitation wavelength in nanometers.
+       location: DMS # The brain area where the stimulation was applied.
+   OptogeneticSeries:
+     name: optogenetic_series
+     site: optogenetic_stimulus_site
+     description: Notes on the optogenetic stimulation.
+     duration: 0.5 # Duration of the optogenetic stimulation in seconds.
+     frequency: 40.0 # Frequency of the optogenetic stimulation in Hz.
+     pulse_width: 0.005 # Pulse width of the optogenetic stimulation in seconds.
+     power: 0.0023 # Power of the optogenetic stimulation in W.
+```

--- a/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_nwbconverter.py
+++ b/src/constantinople_lab_to_nwb/schierek_embargo_2024/schierek_embargo_2024_nwbconverter.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict, List
 from warnings import warn
 
 import numpy as np
+from pynwb import NWBFile
 from neuroconv import NWBConverter
 from neuroconv.datainterfaces import (
     OpenEphysRecordingInterface,
@@ -13,6 +14,7 @@ from neuroconv.utils import FilePathType
 from probeinterface import read_probeinterface, Probe
 
 from constantinople_lab_to_nwb.general_interfaces import BpodBehaviorInterface
+from constantinople_lab_to_nwb.utils import add_optogenetics_series
 
 from constantinople_lab_to_nwb.schierek_embargo_2024.interfaces import (
     SchierekEmbargo2024SortingInterface,
@@ -173,3 +175,8 @@ class SchierekEmbargo2024NWBConverter(NWBConverter):
         for sorting_interface_name in sorting_interface_names:
             sorting_interface = self.data_interface_objects[sorting_interface_name]
             sorting_interface.register_recording(self.data_interface_objects[recording_interface_names[0]])
+
+    def add_to_nwbfile(self, nwbfile: NWBFile, metadata, conversion_options: Optional[dict] = None) -> None:
+        super().add_to_nwbfile(nwbfile=nwbfile, metadata=metadata, conversion_options=conversion_options)
+
+        add_optogenetics_series(nwbfile=nwbfile, metadata=metadata)

--- a/src/constantinople_lab_to_nwb/utils/__init__.py
+++ b/src/constantinople_lab_to_nwb/utils/__init__.py
@@ -1,2 +1,3 @@
 from .fix_xml_openephys import fix_settings_xml_missing_channels
 from .get_subject_metadata import get_subject_metadata_from_rat_info_folder
+from .add_optogenetics_series import add_optogenetics_series

--- a/src/constantinople_lab_to_nwb/utils/add_optogenetics_series.py
+++ b/src/constantinople_lab_to_nwb/utils/add_optogenetics_series.py
@@ -1,0 +1,82 @@
+from warnings import warn
+
+from pynwb import NWBFile
+from pynwb.ogen import OptogeneticStimulusSite, OptogeneticSeries
+from neuroconv.tools.optogenetics import create_optogenetic_stimulation_timeseries
+
+
+def add_optogenetics_series(nwbfile: NWBFile, metadata: dict):
+    """
+    Add optogenetics series to the NWB file.
+
+    Parameters
+    ----------
+    nwbfile: NWBFile
+        The NWB file where the optogenetics series will be added as stimulus.
+    metadata: dict
+        The metadata to use for adding the optogenetics series. The metadata should be located in the "Stimulus" key,
+        with the "OptogeneticSeries" and "OptogeneticStimulusSite" keys containing the metadata for the optogenetic
+        series and stimulus site, respectively.
+
+    """
+
+    if nwbfile.trials is None:
+        warn("No trials found in the NWB file. Please add trials before adding optogenetics series.")
+
+    trials = nwbfile.trials[:]
+    if "is_opto" not in trials.columns:
+        return
+    # %1 = CPIn, 2=SideOff, 3=Reward/OptOut 4=SON, 5=Delay
+    opto_trials = trials[(trials["is_opto"] == True) & (trials["opto_event_type"] == 4)]
+    if opto_trials.empty:
+        return
+
+    bpod_device = nwbfile.devices.get("bpod")
+    if bpod_device is None:
+        raise ValueError(
+            "No Bpod device found in the NWB file. Please add a Bpod device before adding optogenetics series."
+        )
+
+    optogenetics_metadata = metadata["Stimulus"]
+    optogenetic_series_metadata = optogenetics_metadata["OptogeneticSeries"]
+    optogenetic_stimulus_sites_metadata = optogenetics_metadata["OptogeneticStimulusSite"]
+    optogenetic_site_name = optogenetic_series_metadata["site"]
+
+    optogenetic_stimulus_site_metadata = next(
+        (
+            site_metadata
+            for site_metadata in optogenetic_stimulus_sites_metadata
+            if site_metadata["name"] == optogenetic_site_name
+        ),
+        None,
+    )
+    if optogenetic_stimulus_site_metadata is None:
+        raise ValueError(f"Optogenetic stimulus site {optogenetic_site_name} not found in metadata.")
+
+    ogen_stim_site = OptogeneticStimulusSite(
+        name=optogenetic_site_name,
+        description=optogenetic_stimulus_site_metadata["description"],
+        device=bpod_device,
+        excitation_lambda=optogenetic_stimulus_site_metadata["excitation_lambda"],
+        location=optogenetic_stimulus_site_metadata["location"],
+    )
+
+    nwbfile.add_ogen_site(ogen_stim_site)
+
+    timestamps, data = create_optogenetic_stimulation_timeseries(
+        stimulation_onset_times=opto_trials["start_time"].values,
+        duration=optogenetic_series_metadata["duration"],
+        frequency=optogenetic_series_metadata["frequency"],
+        pulse_width=optogenetic_series_metadata["pulse_width"],
+        power=optogenetic_series_metadata["power"],
+    )
+
+    optogenetic_series = OptogeneticSeries(
+        name=optogenetic_series_metadata["name"],
+        description=optogenetic_series_metadata["description"],
+        site=ogen_stim_site,
+        data=data,
+        timestamps=timestamps,
+    )
+
+    nwbfile.add_stimulus(optogenetic_series)


### PR DESCRIPTION
Support adding `OptogeneticsSeries` and `OptogeneticStimulusSite` to NWB file for optogenetics protocol.

The stimulation parameters should be updated in the optogenetics_stimulation_metadata.yaml
The behavior metadata for Bpod data with such protocols ("RWTautowait2OptoTest") is updated to include the additional state types and task arguments.
According to their protocol code (RWTautowait2OptoTest.m) the optogenetic stimulation onsets can be determined from the Bpod data:
-  "IsOpto" - Whether the trial is an optogenetic trial.
 - "OptoEvent" - The type of optogenetic event.  (1 = center port in, 2 = side port off, 3 = Reward or opt-out, 4 = stimulation on, 5 = delay)

We construct the `OptogeneticsSeries` from the stimulation onsets: trials where OptoEvent = 4 
And the stimulation parameters from the yaml file.
